### PR TITLE
chore: Adding missing tests

### DIFF
--- a/docs/hexagonal-architecture-migration.md
+++ b/docs/hexagonal-architecture-migration.md
@@ -13,7 +13,9 @@ Run OpenWhyd Solo locally:
 ```bash
 docker compose up mongo --detach # starts mongo database in the background
 npm install # installs the necessary node modules
+. ./env-vars-testing-local.sh # sets the environment variables
 npm run test-reset # resets and initialises the database
+npm run start:localdb # starts the server locally
 open http://localhost:8080 # opens the local server, use ngx-open on a linux system.
 ```
 

--- a/env-vars-testing-local.sh
+++ b/env-vars-testing-local.sh
@@ -1,0 +1,3 @@
+. ./env-vars-testing.sh
+export MONGODB_PORT=27117
+

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "node app.js $@",
     "start:coverage": "npx nyc --silent node app.js $@",
     "start:localdb": "node app.js $@ --mongoDbDatabase openwhyd_test --mongoDbHost localhost --mongoDbPort 27117",
-    "test-reset": "node test/reset-test-db.js",
+    "test-reset": "export MONGODB_PORT=27117 && node test/reset-test-db.js",
     "test:integration": "npx mocha test/integration/*.js --serial --exit",
     "test:unit": "npx mocha test/unit/*.js --exit",
     "test:approval": "START_WITH_ENV_FILE='./env-vars-testing.conf' mocha test/approval/approval.tests.js $@",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "node app.js $@",
     "start:coverage": "npx nyc --silent node app.js $@",
     "start:localdb": "node app.js $@ --mongoDbDatabase openwhyd_test --mongoDbHost localhost --mongoDbPort 27117",
-    "test-reset": "export MONGODB_PORT=27117 && node test/reset-test-db.js",
+    "test-reset": "node test/reset-test-db.js",
     "test:integration": "npx mocha test/integration/*.js --serial --exit",
     "test:unit": "npx mocha test/unit/*.js --exit",
     "test:approval": "START_WITH_ENV_FILE='./env-vars-testing.conf' mocha test/approval/approval.tests.js $@",

--- a/test/integration/legacy.post.api.tests.js
+++ b/test/integration/legacy.post.api.tests.js
@@ -1,0 +1,146 @@
+var assert = require('assert');
+
+var { DUMMY_USER, cleanup } = require('../fixtures.js');
+var api = require('../api-client.js');
+
+describe(`post api`, function () {
+  before(cleanup); // to prevent side effects between test suites (there are side effects between tests in this file...)
+
+  var pId, uId;
+  const post = {
+    eId: '/yt/XdJVWSqb4Ck',
+    name: 'Lullaby - Jack Johnson and Matt Costa',
+  };
+
+  it(`should allow adding a track`, function (done) {
+    api.loginAs(DUMMY_USER, function (error, { jar }) {
+      api.addPost(jar, post, function (error, { body }) {
+        assert.ifError(error);
+        assert.equal(body.eId, post.eId);
+        assert.equal(body.name, post.name);
+        assert(body._id);
+        pId = body._id;
+        uId = body.uId;
+        done();
+      });
+    });
+  });
+
+  it(`should allow re-adding a track (aka "repost")`, function (done) {
+    api.loginAs(DUMMY_USER, function (error, { jar }) {
+      api.addPost(jar, { pId }, function (error, { body }) {
+        assert.ifError(error);
+        assert(body._id);
+        assert.notEqual(body._id, pId);
+        assert.equal(body.repost.pId, pId);
+        assert.equal(body.eId, post.eId);
+        assert.equal(body.name, post.name);
+        done();
+      });
+    });
+  });
+
+  var playlistFullId;
+  const firstPlaylistIndex = 0;
+  const postInPlaylist = Object.assign({}, post, {
+    pl: {
+      id: 'create',
+      name: 'my first playlist',
+    },
+  });
+
+  it(`should allow adding a track to a playlist`, function (done) {
+    api.loginAs(DUMMY_USER, function (error, { jar }) {
+      api.addPost(jar, postInPlaylist, function (error, { body }) {
+        assert.ifError(error);
+        assert(body._id);
+        assert.equal(body.eId, postInPlaylist.eId);
+        assert.equal(body.name, postInPlaylist.name);
+        assert.equal(body.pl.id, firstPlaylistIndex);
+        assert.equal(body.pl.name, postInPlaylist.pl.name);
+        done();
+      });
+    });
+  });
+
+  it(`make sure that the playlist was created`, function (done) {
+    api.loginAs(DUMMY_USER, function (error, { jar }) {
+      api.getUser(jar, {}, function (error, { body }) {
+        assert.equal(body.pl.length, 1);
+        assert.equal(body.pl[0].id, firstPlaylistIndex);
+        assert.equal(body.pl[0].name, postInPlaylist.pl.name);
+        assert.equal(body.pl[0].nbTracks, 1);
+        playlistFullId = [body.id, firstPlaylistIndex].join('_');
+        done();
+      });
+    });
+  });
+
+  it(`should find 1 track in the playlist`, function (done) {
+    api.loginAs(DUMMY_USER, function (error, { jar }) {
+      api.getPlaylist(jar, playlistFullId, function (error, { body }) {
+        assert.ifError(error);
+        assert.equal(body.length, 1);
+        assert.equal(body[0].id, playlistFullId);
+        assert.equal(body[0].plId, firstPlaylistIndex);
+        assert.equal(body[0].nbTracks, 1);
+        done();
+      });
+    });
+  });
+
+  it(`should return 1 track in the playlist`, function (done) {
+    api.loginAs(DUMMY_USER, function (error, { jar }) {
+      api.getPlaylistTracks(
+        jar,
+        `u/${uId}`,
+        firstPlaylistIndex,
+        function (error, { body }) {
+          assert.equal(body.length, 1);
+          assert.equal(body[0].pl.id, firstPlaylistIndex);
+          assert.equal(body[0].pl.name, postInPlaylist.pl.name);
+          done();
+        }
+      );
+    });
+  });
+
+  it(`should return 1 track in the playlist, with limit=1000`, function (done) {
+    api.loginAs(DUMMY_USER, function (error, { jar }) {
+      const url = `/u/${uId}/playlist/${firstPlaylistIndex}?format=json&limit=1000`;
+      api.get(jar, url, function (error, { body }) {
+        assert.equal(body.length, 1);
+        assert.equal(body[0].pl.id, firstPlaylistIndex);
+        assert.equal(body[0].pl.name, postInPlaylist.pl.name);
+        done();
+      });
+    });
+  });
+
+  it(`should return tracks if two limit parameters are provided`, function (done) {
+    api.loginAs(DUMMY_USER, function (error, { jar }) {
+      const url = `/u/${uId}/playlist/${firstPlaylistIndex}?format=json&limit=1000&limit=20`;
+      // => the `limit` property will be parsed as ["1000","20"] => causing bug #89
+      api.get(jar, url, function (error, { body }) {
+        assert.notEqual(body.length, 0);
+        done();
+      });
+    });
+  });
+
+  it(`should return the comment data after adding it`, function (done) {
+    api.loginAs(DUMMY_USER, function (error, { jar }) {
+      const comment = {
+        pId,
+        text: 'hello world',
+      };
+      api.addComment(jar, comment, function (error, { body }) {
+        assert.ifError(error);
+        assert.equal(body.pId, comment.pId);
+        assert.equal(body.text, comment.text);
+        assert(body._id);
+        done();
+      });
+    });
+  });
+});

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -23,7 +23,7 @@ describe(`post api`, function () {
       request.post(
         {
           jar,
-          url: `${URL_PREFIX}/api/post?action=insert&eId=%2Ffi%2Fhttps%3A%2F%2Ffile-examples-com.github.io%2Fuploads%2F2017%2F11%2Ffile_example_MP3_700KB.mp3%3F_%3D1645782509315&name=${newName}&src%5Bid%5D=&src%5Bname%5D=&_id=${pId}&pl%5Bname%5D=full+stream&pl%5Bid%5D=null&text=`,
+          url: `${URL_PREFIX}/api/post?action=insert&eId=%2Fyt%2FXdJVWSqb4Ck&name=${newName}&src%5Bid%5D=&src%5Bname%5D=&_id=${pId}&pl%5Bname%5D=full+stream&pl%5Bid%5D=null&text=`,
         },
         (error, response, body) =>
           error ? reject(error) : resolve({ response, body })
@@ -38,6 +38,7 @@ describe(`post api`, function () {
     );
     const postedTrack = JSON.parse(res.body).data;
     assert.equal(postedTrack.name, newName);
+    assert.equal(postedTrack.eId, post.eId);
   });
 
   it(`should allow adding a track`, function (done) {

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -23,7 +23,14 @@ describe(`post api`, function () {
       request.post(
         {
           jar,
-          url: `${URL_PREFIX}/api/post?action=insert&eId=%2Fyt%2FXdJVWSqb4Ck&name=${newName}&src%5Bid%5D=&src%5Bname%5D=&_id=${pId}&pl%5Bname%5D=full+stream&pl%5Bid%5D=null&text=`,
+          form: {
+            action: 'insert',
+            eId: post.eId,
+            name: newName,
+            _id: pId,
+            pl: { id: null, name: 'full stream' },
+          },
+          url: `${URL_PREFIX}/api/post`,
         },
         (error, response, body) =>
           error ? reject(error) : resolve({ response, body })

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -2,8 +2,10 @@ var assert = require('assert');
 const util = require('util');
 const request = require('request');
 
-var { DUMMY_USER, cleanup, URL_PREFIX } = require('../fixtures.js');
+var { ADMIN_USER, cleanup, URL_PREFIX } = require('../fixtures.js');
 var api = require('../api-client.js');
+
+const randomString = () => Math.random().toString(36).substring(2, 9);
 
 describe(`post api`, function () {
   let post;
@@ -13,11 +15,14 @@ describe(`post api`, function () {
 
   beforeEach(async () => {
     post = {
-      eId: `/yt/${Math.random().toString(36).substring(2, 9)}`,
+      eId: `/yt/${randomString()}`,
       name: `Lullaby - Jack Johnson and Matt Costa`,
     };
 
-    ({ jar } = await util.promisify(api.loginAs)(DUMMY_USER));
+    ({ jar } = await util.promisify(api.loginAs)(ADMIN_USER));
+    /* We are forced to use the ADMIN_USER, since DUMMY_USER is mutated by user.api.tests.js and the db cleanup seems to not work for the users collection.
+     * May be initdb_testing.js is not up to date with the current schema?
+     */
   });
 
   it("should edit a track's name", async function () {
@@ -55,26 +60,50 @@ describe(`post api`, function () {
 
   // TODO: "should add a track from a blog"
 
-  // TODO: "should add a track from bookmarklet"
+  it('should add a track from bookmarklet', async function () {
+    const name = randomString();
+    const ctx = 'bk';
+
+    const res = await new Promise((resolve, reject) =>
+      request.post(
+        {
+          jar,
+          form: {
+            action: 'insert',
+            eId: post.eId,
+            name: name,
+            ctx: ctx,
+            pl: { id: null, name: 'full stream' },
+          },
+          url: `${URL_PREFIX}/api/post`,
+        },
+        (error, response, body) =>
+          error ? reject(error) : resolve({ response, body })
+      )
+    );
+    const postedTrack = JSON.parse(res.body);
+    assert.equal(postedTrack.name, name);
+    assert.equal(postedTrack.eId, post.eId);
+    assert.equal(postedTrack.ctx, ctx);
+    assert.equal(postedTrack.isNew, true);
+    assert.equal(postedTrack.uId, ADMIN_USER.id);
+    assert.equal(postedTrack.uNm, ADMIN_USER.name);
+    assert.ok(postedTrack._id);
+    assert.equal(postedTrack.pl, undefined);
+  });
 
   // TODO: "should add a track from hot tracks"
 
   // TODO: "should add a track to an existing playlist"
 
-  // TODO: "should add a track to a new playlist"
+  // TODO: should add a track to a new playlist (where ? if this isnot the bookmarklet ?)
 
-  // TODO: "should warn if about to add a track that I already posted in the past"
-
-  // TODO: fix consistency in naming of tests
-
-  // TODO: "should ask to login if trying to add track without session"
-
-  it('should re-add a track into a new playlist', async function () {
+  it('should add a track into a new playlist from the bookmarklet', async function () {
     const { body } = await util.promisify(api.addPost)(jar, post);
     const pId = body._id;
     const name = body.name;
     const ctx = 'bk';
-    const newPlayListName = 'My New Playlist';
+    const newPlayListName = randomString();
 
     await new Promise((resolve, reject) =>
       request.post(
@@ -106,10 +135,58 @@ describe(`post api`, function () {
     assert.equal(postedTrack.eId, post.eId);
     assert.equal(postedTrack.ctx, ctx);
     assert.equal(postedTrack.pl.name, newPlayListName);
-    assert.equal(postedTrack.uId, DUMMY_USER.id);
-    /*Note: looks like the api is returning isNew=true while inspecting the request with the developer tools on the UI
-      but it doesn't seem to be the case with this test...
-    */
+    assert.equal(postedTrack.uId, ADMIN_USER.id);
+    assert.equal(postedTrack.uNm, ADMIN_USER.name);
+  });
+
+  // TODO: "should warn if about to add a track that I already posted in the past"
+
+  // TODO: fix consistency in naming of tests
+
+  // TODO: "should ask to login if trying to add track without session"
+
+  it('should re-add a track to a new playlist from the stream', async function () {
+    const { body } = await util.promisify(api.addPost)(jar, post);
+    const pId = body._id;
+    const name = body.name;
+    const newPlayListName = randomString();
+
+    const res = await new Promise((resolve, reject) =>
+      request.post(
+        {
+          jar,
+          form: {
+            action: 'insert',
+            eId: post.eId,
+            name: name,
+            pId: pId,
+            pl: { id: 'create', name: newPlayListName },
+          },
+          url: `${URL_PREFIX}/api/post`,
+        },
+        (error, response, body) =>
+          error ? reject(error) : resolve({ response, body })
+      )
+    );
+
+    const postedTrack = JSON.parse(res.body);
+
+    assert.equal(postedTrack.name, name);
+    assert.equal(postedTrack.eId, post.eId);
+    assert.notEqual(postedTrack.pl.id, undefined);
+    assert.equal(postedTrack.pl.name, newPlayListName);
+    assert.equal(postedTrack.uId, ADMIN_USER.id);
+    assert.equal(postedTrack.uNm, ADMIN_USER.name);
+    assert.deepEqual(postedTrack.lov, []);
+    assert.equal(postedTrack.text, '');
+    assert.equal(postedTrack.nbP, 0);
+    assert.equal(postedTrack.nbR, 0);
+
+    assert.notEqual(postedTrack._id, pId);
+
+    assert.equal(postedTrack.repost.pId, pId);
+    assert.equal(postedTrack.repost.uId, ADMIN_USER.id);
+    assert.equal(postedTrack.repost.uNm, ADMIN_USER.name);
   });
 
   // TODO: "should re-add a track into an existing playlist"

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -6,16 +6,21 @@ var { DUMMY_USER, cleanup, URL_PREFIX } = require('../fixtures.js');
 var api = require('../api-client.js');
 
 describe(`post api`, function () {
-  before(cleanup); // to prevent side effects between tests
+  let post;
+  let jar;
 
-  var pId, uId;
-  const post = {
-    eId: '/yt/XdJVWSqb4Ck',
-    name: 'Lullaby - Jack Johnson and Matt Costa',
-  };
+  before(cleanup); // to prevent side effects between test suites
+
+  beforeEach(async () => {
+    post = {
+      eId: `/yt/${Math.random().toString(36).substring(2, 9)}`,
+      name: `Lullaby - Jack Johnson and Matt Costa`,
+    };
+
+    ({ jar } = await util.promisify(api.loginAs)(DUMMY_USER));
+  });
 
   it("should edit a track's name", async function () {
-    const { jar } = await util.promisify(api.loginAs)(DUMMY_USER);
     const { body } = await util.promisify(api.addPost)(jar, post);
     const pId = body._id;
     const newName = 'coucou';
@@ -43,23 +48,9 @@ describe(`post api`, function () {
           error ? reject(error) : resolve({ response, body })
       )
     );
-    const postedTrack = JSON.parse(res.body).data;
+    const { data: postedTrack } = JSON.parse(res.body);
     assert.equal(postedTrack.name, newName);
     assert.equal(postedTrack.eId, post.eId);
-  });
-
-  it(`should allow adding a track`, function (done) {
-    api.loginAs(DUMMY_USER, function (error, { jar }) {
-      api.addPost(jar, post, function (error, { body }) {
-        assert.ifError(error);
-        assert.equal(body.eId, post.eId);
-        assert.equal(body.name, post.name);
-        assert(body._id);
-        pId = body._id;
-        uId = body.uId;
-        done();
-      });
-    });
   });
 
   // TODO: "should add a track from a blog"
@@ -78,22 +69,7 @@ describe(`post api`, function () {
 
   // TODO: "should ask to login if trying to add track without session"
 
-  it(`should allow re-adding a track (aka "repost")`, function (done) {
-    api.loginAs(DUMMY_USER, function (error, { jar }) {
-      api.addPost(jar, { pId }, function (error, { body }) {
-        assert.ifError(error);
-        assert(body._id);
-        assert.notEqual(body._id, pId);
-        assert.equal(body.repost.pId, pId);
-        assert.equal(body.eId, post.eId);
-        assert.equal(body.name, post.name);
-        done();
-      });
-    });
-  });
-
   it('should re-add a track into a new playlist', async function () {
-    const { jar } = await util.promisify(api.loginAs)(DUMMY_USER);
     const { body } = await util.promisify(api.addPost)(jar, post);
     const pId = body._id;
     const name = body.name;
@@ -125,7 +101,7 @@ describe(`post api`, function () {
           error ? reject(error) : resolve({ response, body })
       )
     );
-    const postedTrack = JSON.parse(res.body).data;
+    const { data: postedTrack } = JSON.parse(res.body);
     assert.equal(postedTrack.name, name);
     assert.equal(postedTrack.eId, post.eId);
     assert.equal(postedTrack.ctx, ctx);
@@ -140,110 +116,6 @@ describe(`post api`, function () {
 
   // TODO: "should allow re-adding a track into another playlist"
 
-  var playlistFullId;
-  const firstPlaylistIndex = 0;
-  const postInPlaylist = Object.assign({}, post, {
-    pl: {
-      id: 'create',
-      name: 'my first playlist',
-    },
-  });
-
-  it(`should allow adding a track to a playlist`, function (done) {
-    api.loginAs(DUMMY_USER, function (error, { jar }) {
-      api.addPost(jar, postInPlaylist, function (error, { body }) {
-        assert.ifError(error);
-        assert(body._id);
-        assert.equal(body.eId, postInPlaylist.eId);
-        assert.equal(body.name, postInPlaylist.name);
-        assert.equal(body.pl.id, firstPlaylistIndex);
-        assert.equal(body.pl.name, postInPlaylist.pl.name);
-        done();
-      });
-    });
-  });
-
-  it(`make sure that the playlist was created`, function (done) {
-    api.loginAs(DUMMY_USER, function (error, { jar }) {
-      api.getUser(jar, {}, function (error, { body }) {
-        assert.equal(body.pl.length, 1);
-        assert.equal(body.pl[0].id, firstPlaylistIndex);
-        assert.equal(body.pl[0].name, postInPlaylist.pl.name);
-        assert.equal(body.pl[0].nbTracks, 1);
-        playlistFullId = [body.id, firstPlaylistIndex].join('_');
-        done();
-      });
-    });
-  });
-
-  it(`should find 1 track in the playlist`, function (done) {
-    api.loginAs(DUMMY_USER, function (error, { jar }) {
-      api.getPlaylist(jar, playlistFullId, function (error, { body }) {
-        assert.ifError(error);
-        assert.equal(body.length, 1);
-        assert.equal(body[0].id, playlistFullId);
-        assert.equal(body[0].plId, firstPlaylistIndex);
-        assert.equal(body[0].nbTracks, 1);
-        done();
-      });
-    });
-  });
-
-  it(`should return 1 track in the playlist`, function (done) {
-    api.loginAs(DUMMY_USER, function (error, { jar }) {
-      api.getPlaylistTracks(
-        jar,
-        `u/${uId}`,
-        firstPlaylistIndex,
-        function (error, { body }) {
-          assert.equal(body.length, 1);
-          assert.equal(body[0].pl.id, firstPlaylistIndex);
-          assert.equal(body[0].pl.name, postInPlaylist.pl.name);
-          done();
-        }
-      );
-    });
-  });
-
-  it(`should return 1 track in the playlist, with limit=1000`, function (done) {
-    api.loginAs(DUMMY_USER, function (error, { jar }) {
-      const url = `/u/${uId}/playlist/${firstPlaylistIndex}?format=json&limit=1000`;
-      api.get(jar, url, function (error, { body }) {
-        assert.equal(body.length, 1);
-        assert.equal(body[0].pl.id, firstPlaylistIndex);
-        assert.equal(body[0].pl.name, postInPlaylist.pl.name);
-        done();
-      });
-    });
-  });
-
-  it(`should return tracks if two limit parameters are provided`, function (done) {
-    api.loginAs(DUMMY_USER, function (error, { jar }) {
-      const url = `/u/${uId}/playlist/${firstPlaylistIndex}?format=json&limit=1000&limit=20`;
-      // => the `limit` property will be parsed as ["1000","20"] => causing bug #89
-      api.get(jar, url, function (error, { body }) {
-        assert.notEqual(body.length, 0);
-        done();
-      });
-    });
-  });
-
   // TODO: update post
   // TODO: delete post
-
-  it(`should return the comment data after adding it`, function (done) {
-    api.loginAs(DUMMY_USER, function (error, { jar }) {
-      const comment = {
-        pId,
-        text: 'hello world',
-      };
-      api.addComment(jar, comment, function (error, { body }) {
-        assert.ifError(error);
-        assert.equal(body.pId, comment.pId);
-        assert.equal(body.text, comment.text);
-        assert(body._id);
-        done();
-      });
-    });
-  });
 });


### PR DESCRIPTION
## What does this PR do / solve?
Enhancing test coverage by adding missing tests on the post endpoint.


## Overview of changes

Renaming existing test suite to `legacy.post.api.tests.js`, since the preexisting tests are not FIRST : introducing the test for `should re-add a track into a new playlist` made some tests failed because it introduced a new playlist.
The database is just reset at the beginning of the test suite and not between each tests. Furthermore the testing logic of the existing tests are really linked together.

Note that I wasn't able to write the tests from a blog, bookmarklet and hottracks since I didn't know how it works on the website (and where some of those concepts are).

## How to test this PR?

`npm run test-reset && npm run test:integration`
