### PR TITLE
fix: use kill-port programmatically to end the server during integrat…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "formidable": "^1.2.2",
         "hogan.js": "3.0.2",
         "iconv": ">=3.0.0",
+        "kill-port": "^1.6.1",
         "mongodb": "3.6.3",
         "playemjs": "1.2.2",
         "q-set": "^2.0.8",
@@ -6150,6 +6151,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-them-args": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
+      "integrity": "sha1-dKILqKSr7OWuGZrQPyvMaP38m6U="
+    },
     "node_modules/getos": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
@@ -7350,6 +7356,18 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/kill-port": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-1.6.1.tgz",
+      "integrity": "sha512-un0Y55cOM7JKGaLnGja28T38tDDop0AQ8N0KlAdyh+B1nmMoX8AnNmqPNZbS3mUMgiST51DCVqmbFT1gNJpVNw==",
+      "dependencies": {
+        "get-them-args": "1.3.2",
+        "shell-exec": "1.0.2"
+      },
+      "bin": {
+        "kill-port": "cli.js"
       }
     },
     "node_modules/labeled-stream-splicer": {
@@ -9717,6 +9735,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shell-exec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
+      "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg=="
     },
     "node_modules/shell-quote": {
       "version": "1.7.3",
@@ -15790,6 +15813,11 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "get-them-args": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
+      "integrity": "sha1-dKILqKSr7OWuGZrQPyvMaP38m6U="
+    },
     "getos": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
@@ -16675,6 +16703,15 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
+      }
+    },
+    "kill-port": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-1.6.1.tgz",
+      "integrity": "sha512-un0Y55cOM7JKGaLnGja28T38tDDop0AQ8N0KlAdyh+B1nmMoX8AnNmqPNZbS3mUMgiST51DCVqmbFT1gNJpVNw==",
+      "requires": {
+        "get-them-args": "1.3.2",
+        "shell-exec": "1.0.2"
       }
     },
     "labeled-stream-splicer": {
@@ -18519,6 +18556,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shell-exec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
+      "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg=="
     },
     "shell-quote": {
       "version": "1.7.3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "formidable": "^1.2.2",
     "hogan.js": "3.0.2",
     "iconv": ">=3.0.0",
+    "kill-port": "^1.6.1",
     "mongodb": "3.6.3",
     "playemjs": "1.2.2",
     "q-set": "^2.0.8",

--- a/test/approval/approval.tests.js
+++ b/test/approval/approval.tests.js
@@ -4,6 +4,7 @@ const approvals = require('approvals').mocha();
 const util = require('util');
 const request = require('request');
 const { URL_PREFIX } = require('../fixtures.js');
+const kill = require('kill-port');
 
 const {
   START_WITH_ENV_FILE,
@@ -70,7 +71,7 @@ async function setupTestEnv() {
 
 function teardownTestEnv(context) {
   if (context.serverProcess?.kill && !DONT_KILL) {
-    context.serverProcess.kill('SIGINT');
+    kill(process.env.WHYD_PORT, 'tcp');
   }
 }
 

--- a/test/integration/legacy.post.api.tests.js
+++ b/test/integration/legacy.post.api.tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-
+const kill = require('kill-port');
 var { DUMMY_USER, cleanup } = require('../fixtures.js');
 var api = require('../api-client.js');
 var { START_WITH_ENV_FILE, DEV } = process.env;
@@ -17,7 +17,7 @@ describe(`post api`, function () {
   });
   after(() => {
     if (context.serverProcess?.kill) {
-      context.serverProcess.kill('SIGINT');
+      kill(process.env.WHYD_PORT, 'tcp');
     }
   });
 

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 const util = require('util');
 const request = require('request');
+const kill = require('kill-port');
 
 var { ADMIN_USER, cleanup, URL_PREFIX } = require('../fixtures.js');
 var api = require('../api-client.js');
@@ -23,7 +24,7 @@ describe(`post api`, function () {
   });
   after(() => {
     if (context.serverProcess?.kill) {
-      context.serverProcess.kill('SIGINT');
+      kill(process.env.WHYD_PORT, 'tcp');
     }
   });
   beforeEach(async () => {


### PR DESCRIPTION
## What does this PR do / solve?
Openwhyd server wasn't killed properly after integration and approval tests with coverage computing

## Overview of changes

use kill-port to stop the server properly

## How to test this PR?

```bash
 npm run test:integration:post:coverage
```
