### PR TITLE
`npm run test:integration:post` controls execution of web server (like in the main openwhyd codebase)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start:coverage": "npx nyc --silent node app.js $@",
     "test-reset": "node test/reset-test-db.js",
     "test:integration": "npx mocha test/integration/*.js --serial --exit",
+    "test:integration:post": "START_WITH_ENV_FILE='./env-vars-testing.conf' mocha test/integration/*post.api.tests.js $@",
     "test:unit": "npx mocha test/unit/*.js --exit",
     "test-approval": "npx kill-port --port 8080 >/dev/null; DONT_KILL=1 START_WITH_ENV_FILE='./env-vars-testing.conf' ava test/approval.tests.js $@",
     "test-approval-debug": "npm run test-approval -- --fail-fast --serial",

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -5,8 +5,24 @@ const request = require('request');
 var { DUMMY_USER, cleanup, URL_PREFIX } = require('../fixtures.js');
 var api = require('../api-client.js');
 
+var { START_WITH_ENV_FILE } = process.env;
+const { startOpenwhydServer } = require('../approval-tests-helpers');
+
 describe(`post api`, function () {
   before(cleanup); // to prevent side effects between tests
+  let context = {};
+  before(async () => {
+    if (START_WITH_ENV_FILE) {
+      context.serverProcess = await startOpenwhydServer({
+        startWithEnv: START_WITH_ENV_FILE,
+      });
+    }
+  });
+  after(() => {
+    if (context.serverProcess?.kill) {
+      context.serverProcess.kill('SIGINT');
+    }
+  });
 
   var pId, uId;
   const post = {


### PR DESCRIPTION
Contributes to #7.

## What does this PR do / solve?

When we want to show that integration tests don't pass anymore (after changing the properties of `postQuery`, cf screenshot below), we need to restart openwhyd server manually, which is distracting and makes the live coding session more risky.

![image](https://github.com/openwhyd/openwhyd-solo/assets/531781/fcd36a94-d224-45c6-88ac-327ef64f642d)

## Overview of changes

- add a `npm run test:integration:post` that runs just the tests that we need
- make the corresponding test suite control the execution of openwhyd server, so we don't have to start and kill it manually
